### PR TITLE
Update Dockerfile and Sentieon version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG SENTIEON_VERSION
 RUN test -n "$SENTIEON_VERSION"
 
 LABEL container.base.image="debian:bullseye-20220328-slim" \
-      software.version="${VERSION}" \
+      software.version="${SENTIEON_VERSION}" \
       software.website="https://www.sentieon.com/"
 
 # Download the software from the permalink

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Build a container image for a specific version of the Sentieon tools:
 ```bash
 git clone https://github.com/Sentieon/sentieon-docker.git
 cd sentieon-docker
-docker build --build-arg SENTIEON_VERSION=202112.06 .
+docker build --build-arg SENTIEON_VERSION=202112.07 .
 # ...
 # Successfully built a1575042a0a6
 ```


### PR DESCRIPTION
Simple fix for version label in `Dockerfile`, update to latest version as well.

Other repositories like

- https://github.com/Sentieon/Sentieon-WDL
- https://hub.docker.com/r/sentieon/sentieon-wdl
- https://hub.docker.com/r/sentieon/sentieon-aws

may need equivalent fix/update.